### PR TITLE
Enable mbstring extension in PHP

### DIFF
--- a/build-single.sh
+++ b/build-single.sh
@@ -56,7 +56,7 @@ rm -rf configure
 ./vcsclean
 ./buildconf --force
 
-OPTIONS="--with-openssl --enable-pcntl --enable-hash --with-zlib"
+OPTIONS="--with-openssl --enable-pcntl --enable-hash --enable-mbstring --with-zlib"
 
 ./configure --prefix=${PREFIX}/${VERSION}${POSTFIX} ${EXTRA_FLAGS} ${OPTIONS} || exit 5
 


### PR DESCRIPTION
To test PHPLIB, we need to enable the mbstring extension required by PHPUnit.