### PR TITLE
Disable multibyte regex support

### DIFF
--- a/build-single.sh
+++ b/build-single.sh
@@ -56,7 +56,7 @@ rm -rf configure
 ./vcsclean
 ./buildconf --force
 
-OPTIONS="--with-openssl --enable-pcntl --enable-hash --enable-mbstring --with-zlib"
+OPTIONS="--with-openssl --enable-pcntl --enable-hash --enable-mbstring --disable-mbregex --with-zlib"
 
 ./configure --prefix=${PREFIX}/${VERSION}${POSTFIX} ${EXTRA_FLAGS} ${OPTIONS} || exit 5
 


### PR DESCRIPTION
This works around the oniguruma requirement, which isn't fulfilled on all platforms. Patch build: https://spruce.mongodb.com/version/5f0820bbd6d80a27b313268e/tasks