### PR TITLE
BUILD-13010 add job to build on Ubuntu 18.04

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -126,6 +126,14 @@ buildvariants:
      - name: build-debian-linux-toolchain
      - name: push-debian-linux-binaries
 
+- name: ubuntu1804-amd64
+  display_name: Ubuntu 18.04 AMD64
+  run_on:
+    - ubuntu1804-small
+  tasks:
+     - name: build-debian-linux-toolchain
+     - name: push-debian-linux-binaries
+
 - name: ubuntu1804-arm64
   display_name: Ubuntu 18.04 ARM64
   run_on:


### PR DESCRIPTION
This change introduces an Ubuntu 18.04 (AMD64) builder which is required by [BUILD-13007](https://jira.mongodb.org/browse/BUILD-13007).